### PR TITLE
Modify the bootstrap script to exit on error, clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 **/devopsguru_eks_test/gradle
 **/test_client/venv
 **/__pycache__
+/gradlew
+/gradlew.bat
+/gradle/wrapper
+/devopsguru_eks_test/gradlew
+/devopsguru_eks_test/gradlew.bat

--- a/README.md
+++ b/README.md
@@ -5,46 +5,46 @@ This project allows one to deploy an EKS cluster in their account and trigger va
 ## Requirements
 
 In order to operate this test harness you will need the following:
-* A PC with a unix-based opsystem (GNU/Linux or MacOS) and a shell (bash, dash, zsh)
-* OpenJDK 11
-* Gradle 6+ (https://gradle.org/install/)
-* Python 3.6+ with 'pip' utility (https://pip.pypa.io/en/stable/installation/)
+* A PC with a unix-based opsystem (GNU/Linux or macOS) and a shell (bash, dash, zsh)
+* Onboard used account to AWS DevOps Guru in us-east-1
+* [Gradle](https://gradle.org/install/)
+* [Python 3.6+ with 'pip' utility](https://pip.pypa.io/en/stable/installation/)
 * Docker
-* kubectl utility (https://kubernetes.io/docs/tasks/tools/)
-* eksctl utility (https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
-* aws cli utility (https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-* helm utility (https://helm.sh/docs/intro/install/)
-* Onboard used account to DevOps Guru in us-east-1
+* [kubectl](https://kubernetes.io/docs/tasks/tools/)
+* [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
+* [AWS CLI V2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) - only v2 is supported
+* [Helm](https://helm.sh/docs/intro/install/)
 
 ## Installing the harness
 In order to provision the cluster and install all the necessary elements:
 * Authenticate into your AWS account using credentials that have mutating permissions and set default region to us-east-1
- ```
- aws configure
- ```
+```shell
+aws configure
+```
 
 * Run the bootstrap script in the root folder of the repository.
 
-```
+```shell
 ./bootstrap.sh
 ```
 
 ### Inspecting the cluster
 If you would like to inspect the content of deployed EKS cluster, start kubectl proxy via script in the root of repository
-```
+```shell
 ./start_proxy.sh
 ```
+
 This will allow you to view:
-* Kubernetes dashboard (http://localhost:8001/api/v1/namespaces/default/services/https:kubernetes-dashboard:https/proxy/#/workloads?namespace=default)
-* Prometheus server web interface (http://localhost:9090/graph?g0.expr=&g0.tab=1&g0.stacked=0&g0.range_input=1h)
+* [Kubernetes dashboard](http://localhost:8001/api/v1/namespaces/default/services/https:kubernetes-dashboard:https/proxy/#/workloads?namespace=default)
+* [Prometheus server web interface](http://localhost:9090/graph?g0.expr=&g0.tab=1&g0.stacked=0&g0.range_input=1h)
 
 In order to stop proxy process simply run
-```
+```shell
 ./stop_proxy.sh
 ```
 
 In order to get access token for Kubernetes dashboard run
-```
+```shell
 ./get_dashboard_token.sh
 ```
 
@@ -53,7 +53,7 @@ In order to get access token for Kubernetes dashboard run
 Before running tests, please make sure that your cluster has been running for at least 60 minutes, to give DevOps Guru a chance to ingest and index all the metrics.
 
 In order to run test cases, make sure you have Python 3.6+ interpreter installed and run:
-```
+```shell
 ./run_test.sh <test_name>
 ```
 

--- a/aws_load_balancer_controller/remove_load_balancer_controller.sh
+++ b/aws_load_balancer_controller/remove_load_balancer_controller.sh
@@ -8,8 +8,8 @@ helm uninstall -n kube-system aws-load-balancer-controller
 eksctl delete iamserviceaccount \
   --cluster=DevOpsGuruTestCluster \
   --namespace=kube-system \
-  --name=aws-load-balancer-controller 
+  --name=aws-load-balancer-controller
 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
-aws iam delete-policy --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/DevOpsGuruAWSLoadBalancerControllerIAMPolicy
+aws iam delete-policy --policy-arn arn:aws:iam::"${AWS_ACCOUNT_ID}":policy/DevOpsGuruAWSLoadBalancerControllerIAMPolicy

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,53 +3,55 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-#Bootstrap initial cluster and node group
-cd cluster_bootstrap
-sh create_cluster.sh
-cd ..
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_PAGER=""
 
-#Install kube dashboard
-cd kubernetes_dashboard
-sh install_dashboard.sh
-cd ..
+echo "Bootstrap initial cluster and node group"
+(
+  cd cluster_bootstrap && sh create_cluster.sh || exit 1
+)
 
-#Install ChaosMesh
-cd chaos_mesh
-sh install_chaos_mesh.sh
-cd ..
+echo "Install kube dashboard"
+(
+  cd kubernetes_dashboard && sh install_dashboard.sh || exit 1
+)
 
-#Install prometheus
-cd prometheus
-sh install_prometheus.sh
-cd ..
+echo "Install ChaosMesh"
+(
+  cd chaos_mesh && sh install_chaos_mesh.sh || exit 1
+)
 
-#Install Kong
-cd kong
-sh install_kong.sh
-cd ..
+echo "Install prometheus"
+(
+  cd prometheus && sh install_prometheus.sh || exit 1
+)
 
-#Add ALB controller
-cd aws_load_balancer_controller
-sh create_load_balancer_controller.sh
-cd ..
+echo "Install Kong"
+(
+  cd kong && sh install_kong.sh || exit 1
+)
 
-#Create ECR repo
-cd ecr
-sh create_repo.sh
-cd ..
+echo "Add ALB controller"
+(
+  cd aws_load_balancer_controller && sh create_load_balancer_controller.sh || exit 1
+)
 
-#Install Redis
-cd redis
-sh install_redis.sh
-cd ..
+echo "Create ECR repo"
+(
+  cd ecr && sh create_repo.sh || exit 1
+)
 
-#Build and install test deployment
-cd devopsguru_eks_test
-sh build.sh
-sh install_chart.sh
-cd ..
+echo "Install Redis"
+(
+  cd redis && sh install_redis.sh || exit 1
+)
 
-#Install test client requirements
-cd test_client
-pip install -r requirements.txt
-cd ..
+echo "Build and install test deployment"
+(
+  cd devopsguru_eks_test && sh build.sh && sh install_chart.sh || exit 1
+)
+
+echo "Install test client requirements"
+(
+  cd test_client && pip3 install -r requirements.txt || exit 1
+)

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,25 +3,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-#Remove test deployment
-cd devopsguru_eks_test
-sh uninstall_chart.sh
-cd ..
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_PAGER=""
 
+echo "Remove test deployment"
+(cd devopsguru_eks_test && sh uninstall_chart.sh)
+
+echo "Waiting 5 minutes for resources to be removed..."
 sleep 300
 
-#Cleanup ECR repo
-cd ecr
-sh remove_repo.sh
-cd ..
+echo "Cleanup ECR repo"
+(cd ecr && sh remove_repo.sh)
 
-#Remove load balancer controller 
-cd aws_load_balancer_controller
-sh remove_load_balancer_controller.sh
-cd ..
+echo "Remove load balancer controller"
+(cd aws_load_balancer_controller && sh remove_load_balancer_controller.sh)
 
-#Cleanup cluster
-cd cluster_bootstrap
-sh remove_cluster.sh
-cd ..
-
+echo "Cleanup cluster"
+(cd cluster_bootstrap && sh remove_cluster.sh)

--- a/cluster_bootstrap/create_cluster.sh
+++ b/cluster_bootstrap/create_cluster.sh
@@ -3,15 +3,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-#Create cluster 
-eksctl create cluster --name DevOpsGuruTestCluster --version 1.21 --with-oidc --nodegroup-name Group1 --node-type t3.medium --nodes 3 --nodes-min 1 --nodes-max 4
+# Create cluster
+eksctl create cluster \
+  --name DevOpsGuruTestCluster \
+  --version 1.21 \
+  --with-oidc \
+  --nodegroup-name Group1 \
+  --node-type t3.medium \
+  --nodes 3 \
+  --nodes-min 1 \
+  --nodes-max 4 \
+  --zones us-east-1a,us-east-1b,us-east-1c
 
-#Create admin service account for further use
+# Create admin service account for further use
 kubectl apply -f eks-admin-service-account.yaml
 
-#Set up opentelemetry for container insights
+# Set up opentelemetry for container insights
 ROLE_NAME=$(echo $(kubectl -n kube-system get cm -o yaml aws-auth | grep rolearn) | awk -F'role/' '{print $2}')
 aws iam attach-role-policy \
---policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy \
---role-name $ROLE_NAME
+  --policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy \
+  --role-name "$ROLE_NAME"
+
 kubectl apply -f otel-container-insights-infra.yaml

--- a/cluster_bootstrap/eks-admin-service-account.yaml
+++ b/cluster_bootstrap/eks-admin-service-account.yaml
@@ -6,7 +6,7 @@ metadata:
   name: eks-admin
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eks-admin
@@ -15,6 +15,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: eks-admin
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: eks-admin
+    namespace: kube-system

--- a/devopsguru_eks_test/build.sh
+++ b/devopsguru_eks_test/build.sh
@@ -8,8 +8,8 @@ gradle wrapper
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 ./gradlew bootBuildImage --imageName=devopsguru/devopsguru-eks-test
 
-ECR_TOKEN=$(aws ecr get-login-password --region us-east-1)
-docker login -u AWS -p ${ECR_TOKEN} https://${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID".dkr.ecr.us-east-1.amazonaws.com
 
-docker tag devopsguru/devopsguru-eks-test:latest ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/devopsguru-eks-test:latest
-docker push ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/devopsguru-eks-test:latest
+docker tag devopsguru/devopsguru-eks-test:latest "${AWS_ACCOUNT_ID}".dkr.ecr.us-east-1.amazonaws.com/devopsguru-eks-test:latest
+docker push "${AWS_ACCOUNT_ID}".dkr.ecr.us-east-1.amazonaws.com/devopsguru-eks-test:latest

--- a/ecr/create_repo.sh
+++ b/ecr/create_repo.sh
@@ -3,5 +3,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-aws ecr get-login --region us-east-1 | eval
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
 aws ecr create-repository --repository-name devopsguru-eks-test --image-scanning-configuration scanOnPush=true --region us-east-1


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:*

When the bootstrapping or cleanup sequence fail we generally don't want to continue with the next
step because there are dependencies between them. I've turned the comments in the scripts to `echo`s to inform the user what is the current step.

Part of this commit is also a cleanup of the README and migration to AWS CLI v2.

Another issue I had was that the CLI is using a pager (less I think in my case) to display the API responses which blocks the script until you close the page. I've set the AWS_PAGER to an empty string to prevent this from happening and allow the script to finish without any user interaction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
