### PR TITLE
Update install_chaos_mesh.sh to use version 2.3.0

### DIFF
--- a/chaos_mesh/install_chaos_mesh.sh
+++ b/chaos_mesh/install_chaos_mesh.sh
@@ -7,4 +7,4 @@ helm repo add chaos-mesh https://charts.chaos-mesh.org
 
 kubectl create namespace chaos-testing
 
-helm install chaos-mesh chaos-mesh/chaos-mesh --namespace chaos-testing --version 2.0.3
+helm install chaos-mesh chaos-mesh/chaos-mesh --namespace chaos-testing --version 2.3.0


### PR DESCRIPTION
PR from @ande28em: Upgraded chaos mesh version to 2.3.0. This fixes deprecated API errors caused by the upgrade to Kubernetes v1.22.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
