### PR TITLE
Various fixes after dependencies update

### DIFF
--- a/devopsguru_eks_test/build.sh
+++ b/devopsguru_eks_test/build.sh
@@ -8,6 +8,11 @@ gradle wrapper
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 REGION=$(../get_region.sh)
 
+# If you are building on macOS and use a newer Docker desktop the build might not work
+# See https://github.com/spring-projects/spring-boot/issues/32897
+# Solution is to create a symlink to the Docker socket in /var/run:
+# sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock
+
 ./gradlew bootBuildImage --imageName=devopsguru/devopsguru-eks-test
 
 aws ecr get-login-password \

--- a/devopsguru_eks_test/chart/values.yaml
+++ b/devopsguru_eks_test/chart/values.yaml
@@ -5,7 +5,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 9
+replicaCount: 6
 
 image:
   repository: ""
@@ -60,21 +60,16 @@ ingress:
   #      - chart-example.local
 
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-     cpu: 600m
      memory: 600Mi
   requests:
      cpu: 300m
-     memory: 500Mi
+     memory: 600Mi
 
 autoscaling:
   enabled: false
-  minReplicas: 1
-  maxReplicas: 100
+  minReplicas: 3
+  maxReplicas: 12
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 

--- a/test_scenarios/build.gradle.kts
+++ b/test_scenarios/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-api-kotlin:1.2.0")
     implementation("org.apache.logging.log4j:log4j-api:$log4j2Version")
     implementation("org.apache.logging.log4j:log4j-core:$log4j2Version")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4j2Version")
+    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4j2Version")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$coroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")


### PR DESCRIPTION
- Use the correct version of binding between Slf4j and Log4j2 after Slf4j update
- Add instructions how to build on macOS in case of a failure
- Use less replicas and follow the best practice of limits=requests for memory to make the app deployment stable during upgrades when resources are scarce

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
