### PR TITLE
Fix CW Logs FluentBit permissions

### DIFF
--- a/cluster_bootstrap/enable_cloudwatch_container_logs.sh
+++ b/cluster_bootstrap/enable_cloudwatch_container_logs.sh
@@ -7,6 +7,15 @@ RegionName=$(../get_region.sh)
 FluentBitHttpPort='2020'
 FluentBitReadFromHead='Off'
 
+# Attach CW Policy to service account
+eksctl create iamserviceaccount \
+    --name fluent-bit \
+    --namespace amazon-cloudwatch \
+    --cluster $ClusterName \
+    --attach-policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy \
+    --approve \
+    --override-existing-serviceaccounts
+
 [[ ${FluentBitReadFromHead} = 'On' ]] && FluentBitReadFromTail='Off' || FluentBitReadFromTail='On'
 [[ -z ${FluentBitHttpPort} ]] && FluentBitHttpServer='Off' || FluentBitHttpServer='On'
 


### PR DESCRIPTION
*Description of changes:*

Logs failed to get created due to a AccessDenied exception. Attach the CW Agent policy used by the container insights role to allow the agent to create logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
